### PR TITLE
Enable matching attributes with spaces in the attribute value

### DIFF
--- a/src/Document/Query.php
+++ b/src/Document/Query.php
@@ -78,9 +78,20 @@ class Query
             return implode('|', $expressions);
         }
 
+        // Arbitrary attribute value contains whitespace
+        $path = preg_replace_callback(
+            '/\[\S+["\'](.+)["\']\]/',
+            function ($matches) {
+                return str_replace($matches[1], preg_replace('/\s+/', '{--WHITESPACE--}', $matches[1]), $matches[0]);
+            },
+            $path
+        );
+
         $paths    = ['//'];
         $path     = preg_replace('|\s+>\s+|', '>', $path);
         $segments = preg_split('/\s+/', $path);
+        $segments = str_replace('{--WHITESPACE--}', ' ', $segments);
+
         foreach ($segments as $key => $segment) {
             $pathSegment = static::_tokenize($segment);
             if (0 == $key) {

--- a/src/Document/Query.php
+++ b/src/Document/Query.php
@@ -82,7 +82,7 @@ class Query
         $path = preg_replace_callback(
             '/\[\S+["\'](.+)["\']\]/',
             function ($matches) {
-                return str_replace($matches[1], preg_replace('/\s+/', '{--WHITESPACE--}', $matches[1]), $matches[0]);
+                return str_replace($matches[1], preg_replace('/\s+/', '\s', $matches[1]), $matches[0]);
             },
             $path
         );
@@ -90,7 +90,7 @@ class Query
         $paths    = ['//'];
         $path     = preg_replace('|\s+>\s+|', '>', $path);
         $segments = preg_split('/\s+/', $path);
-        $segments = str_replace('{--WHITESPACE--}', ' ', $segments);
+        $segments = str_replace('\s', ' ', $segments);
 
         foreach ($segments as $key => $segment) {
             $pathSegment = static::_tokenize($segment);

--- a/test/DocumentTest.php
+++ b/test/DocumentTest.php
@@ -170,6 +170,13 @@ class DocumentTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, count($result));
     }
 
+    public function testQueryShouldFindNodesWithArbitraryAttributeSelectorsThatIncludeSpaces()
+    {
+        $this->loadHtml();
+        $result = Document\Query::execute('div[data-attr="foo bar baz"]', $this->document, Document\Query::TYPE_CSS);
+        $this->assertEquals(1, count($result));
+    }
+
     public function testQueryShouldFindNodesWithArbitraryAttributeSelectorsAsDiscreteWords()
     {
         $this->loadHtml();

--- a/test/_files/sample.xhtml
+++ b/test/_files/sample.xhtml
@@ -88,7 +88,7 @@
                 </form>
             </div>
 
-            <div class="navblock" dojoType="FilteringSelect">
+            <div class="navblock" dojoType="FilteringSelect" data-attr="foo bar baz">
                 <ul>
                     <li class="foo" dojoType="foo bar">Item 1</li>
                     <li class="foo current">Item 2</li>


### PR DESCRIPTION
This PR attempts to address `Zend\Dom\Document\Query::execute()` failing for attribute selectors that contain spaces.

`Zend\Dom\Document\Query::cssToXpath()` contains a `preg_split()` operation, which breaks the path up before tokenizing the string. Unfortunately, this fails with a perfectly valid selector such as `input[value="Marty McFly"]`, causing the selector to be interpreted as two separate queries.

I don't love the approach taken here (replacing whitespace within attribute selectors with a token, then doing string replacement following the `preg_split()`], but I'll admit my knowledge of XPath is pretty slim, and my regex-fu with lookaround assertions is failing me. If someone else has a better recommendation on how to approach the problem, I'm all ears :)

At the very least, the PR enables this kind of matching, as well as introduces a test to verify the behavior. 

Fixes #17.