### PR TITLE
Nested attribute selectors

### DIFF
--- a/src/Document/Query.php
+++ b/src/Document/Query.php
@@ -88,7 +88,7 @@ class Query
 
         // Arbitrary attribute value contains whitespace
         $path = preg_replace_callback(
-            '/\[\S+["\']([\w\s]+)["\']\]/',
+            '/\[\S+?["\'](.+?)["\']\]/',
             function ($matches) {
                 return str_replace($matches[1], preg_replace('/\s+/', '\s', $matches[1]), $matches[0]);
             },

--- a/src/Document/Query.php
+++ b/src/Document/Query.php
@@ -88,7 +88,7 @@ class Query
 
         // Arbitrary attribute value contains whitespace
         $path = preg_replace_callback(
-            '/\[\S+["\'](.+)["\']\]/',
+            '/\[\S+["\']([\w\s]+)["\']\]/',
             function ($matches) {
                 return str_replace($matches[1], preg_replace('/\s+/', '\s', $matches[1]), $matches[0]);
             },

--- a/test/Document/QueryTest.php
+++ b/test/Document/QueryTest.php
@@ -172,4 +172,10 @@ class QueryTest extends TestCase
         $test = Query::cssToXpath('a[@href="http://example.com"]');
         $this->assertEquals("//a[@href='http://example.com']", $test);
     }
+
+    public function testTransformNestedAttributeSelectors()
+    {
+        $test = Query::cssToXpath('select[name="foo"] option[selected="selected"]');
+        $this->assertEquals("//select[@name='foo']//option[@selected='selected']", $test);
+    }
 }


### PR DESCRIPTION
[6ae9938](https://github.com/zendframework/zend-dom/commit/6ae9938baa992d01774b8caf1510399681f42d8b)/2.7.0 introduced a bug where nested attribute selectors (`div[class="foo"] div[class="bar"]`) aren't transformed to XPath properly anymore. Does anyone have an idea how we could fix this?