### PR TITLE
Added missing DOMNode class import

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -10,6 +10,7 @@
 namespace Zend\Dom;
 
 use DOMDocument;
+use DOMNode;
 
 /**
  * Query DOM structures based on CSS selectors and/or XPath


### PR DESCRIPTION
It is used in that class but it's not imported nor defined in that namespace

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [ ] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.
